### PR TITLE
composable: refactor validation into composable and utils

### DIFF
--- a/src/components/basic/UInput.vue
+++ b/src/components/basic/UInput.vue
@@ -4,7 +4,7 @@
       <span v-if="required"> *</span>
     </label>
     <input :type="type" :value="modelValue"
-           @change="$emit('update:modelValue', $event.target.value); validate($event.target.value);"
+           @change="$emit('update:modelValue', $event.target.value); validate(state, props, $event.target.value);"
            :class="classes"
            :placeholder="placeholder"/>
     <p v-if="!state.valid" v-for="error in state.errors" class="mt-1 text-sm text-red-600" id="error">{{ error }}</p>
@@ -13,6 +13,7 @@
 
 <script setup>
 import {computed, reactive} from 'vue'
+import {validate} from '@/composable/useValidation.js'
 
 const state = reactive({valid: true, errors: []})
 
@@ -49,30 +50,5 @@ const classes = computed(() => {
   }
 })
 
-function validate(value) {
-  state.valid = true
-  state.errors = []
-  if (props.required) {
-    isEmpty(value)
-  }
 
-  if (state.valid && props.type === 'email') {
-    isEMailValid(value)
-  }
-}
-
-function isEmpty(value) {
-  if (value.length === 0) {
-    state.valid = false
-    state.errors.push('This field cannot be empty')
-  }
-}
-
-// TODO externalize in a specific file once more rules are defined
-function isEMailValid(email) {
-  if (!(/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(email))) {
-    state.valid = false
-    state.errors.push('The email is not valid')
-  }
-}
 </script>

--- a/src/components/stepper/StepperBullet.vue
+++ b/src/components/stepper/StepperBullet.vue
@@ -42,6 +42,7 @@ import {storeToRefs} from 'pinia'
 import {useStore} from '@/store/stepper.js'
 import {useStoreDisplay} from '@/store/display.js'
 import UButton from '@/components/basic/UButton.vue'
+import {isFormValid} from '@/utils/validation.js'
 
 const props = defineProps({
       steps: {
@@ -84,14 +85,6 @@ function previous() {
   store.$patch({
     mainNavigationDisplayed: true
   })
-}
-
-async function isFormValid() {
-  if (process.env.VUE_APP_DEBUG && JSON.parse(process.env.VUE_APP_DEBUG)) return true
-
-  const elements = document.querySelectorAll('input')
-  await elements.forEach(e => e.dispatchEvent(new Event('change')))
-  return !document.getElementById('error')
 }
 
 </script>

--- a/src/components/stepper/StepperNavigation.vue
+++ b/src/components/stepper/StepperNavigation.vue
@@ -13,6 +13,7 @@ import {useStore} from '@/store/stepper.js'
 import {useStoreData} from '@/store/data.js'
 import {useStoreDisplay} from '@/store/display.js'
 import UButton from '@/components/basic/UButton.vue'
+import {isFormValid} from '@/utils/validation.js'
 
 const store = useStore()
 const storeData = useStoreData()
@@ -37,13 +38,5 @@ function previous() {
   storeDisplay.$reset()
 }
 
-async function isFormValid() {
-  if (process.env.VUE_APP_DEBUG && JSON.parse(process.env.VUE_APP_DEBUG)) return true
-
-  // TODO maybe use $refs https://vuejs.org/guide/essentials/template-refs.html#ref-on-component
-  const elements = document.querySelectorAll('input')
-  await elements.forEach(e => e.dispatchEvent(new Event('change')))
-  return !document.getElementById('error')
-}
 
 </script>

--- a/src/composable/useValidation.js
+++ b/src/composable/useValidation.js
@@ -1,0 +1,22 @@
+import {ERROR_MESSAGES, isEMailValid, isEmpty} from '@/utils/validation.js'
+
+export function validate(state, props, value) {
+    state.valid = true
+    state.errors = []
+    if (props.required) {
+        if (isEmpty(value)) {
+            writeError(state, ERROR_MESSAGES.EMPTY)
+        }
+    }
+
+    if (state.valid && props.type === 'email') {
+        if (!isEMailValid(state, value)) {
+            writeError(state, ERROR_MESSAGES.EMPTY)
+        }
+    }
+}
+
+function writeError(state, errorMessage) {
+    state.valid = false
+    state.errors.push(errorMessage)
+}

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,22 @@
+export async function isFormValid() {
+    if (process.env.VUE_APP_DEBUG && JSON.parse(process.env.VUE_APP_DEBUG)) return true
+    // TODO maybe use $refs https://vuejs.org/guide/essentials/template-refs.html#ref-on-component
+    const elements = document.querySelectorAll('input')
+    await elements.forEach(e => e.dispatchEvent(new Event('change')))
+    return !document.getElementById('error')
+}
+
+export function isEmpty(value) {
+    return !(!value || value.length === 0)
+}
+
+export function isEMailValid(email) {
+    // TODO review this regexp
+    return /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(email)
+
+}
+
+export const ERROR_MESSAGES = {
+    EMPTY: 'This field cannot be empty',
+    EMAIL: 'The email is not valid'
+}

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -6,6 +6,7 @@ export async function isFormValid() {
     return !document.getElementById('error')
 }
 
+// TODO should use is_js https://www.npmjs.com/package/is_js
 export function isEmpty(value) {
     return !(!value || value.length === 0)
 }


### PR DESCRIPTION
The goal was to externalize some functions (in this case related to validation but I want to do it the proper way for future uses) that were inside components. Some because I want to use them at multiple places others because it'll be cleaner to have them into their own files.
I've asked Jules about the proper way to do it this morning and he told it about mixins but it's [deprecated](https://vuejs.org/api/options-composition.html#mixins) in Vue 3 : 
> No Longer Recommended
>
> In Vue 2, mixins were the primary mechanism for creating reusable chunks of component logic. While mixins continue to be supported in Vue 3, [Composition API](https://vuejs.org/guide/reusability/composables.html) is now the preferred approach for code reuse between components.

So I've looked into "composable" and they're functions with stateful logic. Therefore I decided to divide my functions into two files : 

- [a composable](https://github.com/progressive-identity/uropa-ui/blob/f829a9a9de123a36746b01081f44313daf26a6e5/src/composable/useValidation.js) for stateful functions
- [a utils](https://github.com/progressive-identity/uropa-ui/blob/f829a9a9de123a36746b01081f44313daf26a6e5/src/utils/validation.js) for stateless functions

Anyway I'd like your feedback (@mkanzit I think you're the expert about mixins and these kind of things) on this structure. I'm not very familiar with Vue or stateful/stateless functions so maybe it does not make any sense don't hesitate !
As for the content of the functions itself I'll probably rework it once all the rules for validation are defined, but you can still provides feedback if you want. 